### PR TITLE
Fixed OS X build: use `clang` instead of `ld`

### DIFF
--- a/railing/railing.erl
+++ b/railing/railing.erl
@@ -37,7 +37,7 @@ ld(xen_x86) ->
 ld(posix_x86) ->
 	case os:type() of
 		{unix, darwin} -> [
-			"ld",
+			"clang",
 			"-image_base", "0x8000",
 			"-pagezero_size", "0x8000",
 			"-arch", "x86_64",


### PR DESCRIPTION
I use OS X 10.10.3, could not build a ling image with `ld`, but it builds using `clang`. 

Please verify if it works on your system.
